### PR TITLE
Add Supabase historical score endpoint and realtime chart animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@supabase/supabase-js": "^2.53.0",
     "@tanstack/react-query": "^5.56.2",
     "class-variance-authority": "^0.7.1",
-    "marked": "^12.0.2"
+    "marked": "^12.0.2",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
@@ -64,7 +64,8 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
     "xlsx": "^0.18.5",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "framer-motion": "^11.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
@@ -84,5 +85,5 @@
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"
   },
-  "description": "A Vite + React + TypeScript app with shadcn/ui. Cleaned of template tags and set up for environment-based secrets."
+  "description": "A Vite + React + TypeScript app using shadcn/ui."
 }

--- a/src/components/EnhancedCharts.tsx
+++ b/src/components/EnhancedCharts.tsx
@@ -1,21 +1,18 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, PieChart, Pie, Cell, LineChart, Line, AreaChart, Area } from 'recharts';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { TrendingUp, TrendingDown, Award, Target } from 'lucide-react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { supabase } from '@/integrations/supabase/client';
 
-interface ChartData {
-  name: string;
-  value: number;
-  benchmark?: number;
-  trend?: number;
-  color?: string;
-}
+// ChartData interface removed; charts derive structure from fetched data
 
 interface EnhancedChartsProps {
   scores: Record<string, number>;
   benchmarks?: Record<string, number>;
   trends?: Record<string, number>;
+  dealershipId?: string;
 }
 
 const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4'];
@@ -56,16 +53,58 @@ export const EnhancedCharts: React.FC<EnhancedChartsProps> = ({
     { range: '<60', count: Object.values(scores).filter(s => s < 60).length, color: '#ef4444' }
   ];
 
-  // Trend analysis data (simulated historical data)
-  const trendData = Array.from({ length: 6 }, (_, i) => {
-    const month = new Date();
-    month.setMonth(month.getMonth() - (5 - i));
-    return {
-      month: month.toLocaleDateString('en', { month: 'short' }),
-      overall: Object.values(scores).reduce((a, b) => a + b, 0) / Object.values(scores).length + (Math.random() - 0.5) * 10,
-      target: 80
+  interface TrendPoint {
+    month: string;
+    overall: number;
+    target: number;
+  }
+
+  const [trendData, setTrendData] = useState<TrendPoint[]>([]);
+
+  useEffect(() => {
+    if (!dealershipId) return;
+
+    const fetchData = async () => {
+      const { data, error } = await supabase.rpc('get_historical_scores', {
+        dealership_id: dealershipId,
+      });
+      if (!error && data) {
+        const mapped = data.map((row: { created_at: string; overall_score: number }) => ({
+          month: new Date(row.created_at).toLocaleDateString('en', { month: 'short' }),
+          overall: row.overall_score || 0,
+          target: 80,
+        }));
+        setTrendData(mapped);
+      }
     };
-  });
+
+    fetchData();
+
+    const channel = supabase
+      .channel('score_changes')
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'assessments',
+          filter: `dealership_id=eq.${dealershipId}`,
+        },
+        (payload) => {
+          const newPoint = {
+            month: new Date(payload.new.created_at).toLocaleDateString('en', { month: 'short' }),
+            overall: payload.new.overall_score || 0,
+            target: 80,
+          };
+          setTrendData((prev) => [...prev, newPoint]);
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [dealershipId]);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -170,29 +209,40 @@ export const EnhancedCharts: React.FC<EnhancedChartsProps> = ({
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <ResponsiveContainer width="100%" height={300}>
-            <AreaChart data={trendData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="month" />
-              <YAxis domain={[50, 100]} />
-              <Tooltip />
-              <Area
-                type="monotone"
-                dataKey="overall"
-                stroke="#3b82f6"
-                fill="#3b82f6"
-                fillOpacity={0.3}
-                name="Overall Performance"
-              />
-              <Line
-                type="monotone"
-                dataKey="target"
-                stroke="#10b981"
-                strokeDasharray="5 5"
-                name="Target"
-              />
-            </AreaChart>
-          </ResponsiveContainer>
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={trendData.length}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+            >
+              <ResponsiveContainer width="100%" height={300}>
+                <AreaChart data={trendData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="month" />
+                  <YAxis domain={[50, 100]} />
+                  <Tooltip />
+                  <Area
+                    type="monotone"
+                    dataKey="overall"
+                    stroke="#3b82f6"
+                    fill="#3b82f6"
+                    fillOpacity={0.3}
+                    name="Overall Performance"
+                    isAnimationActive
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="target"
+                    stroke="#10b981"
+                    strokeDasharray="5 5"
+                    name="Target"
+                    isAnimationActive
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </motion.div>
+          </AnimatePresence>
         </CardContent>
       </Card>
 

--- a/supabase/migrations/20250803050000_get_historical_scores.sql
+++ b/supabase/migrations/20250803050000_get_historical_scores.sql
@@ -1,0 +1,15 @@
+-- create function to fetch historical scores for a dealership
+create or replace function public.get_historical_scores(dealership_id uuid)
+returns table(
+  created_at timestamptz,
+  overall_score double precision
+) as $$
+  select created_at, overall_score
+  from assessments
+  where assessments.dealership_id = get_historical_scores.dealership_id
+  order by created_at;
+$$ language sql stable;
+
+-- allow anon and authenticated users to execute
+grant execute on function public.get_historical_scores(uuid) to anon, authenticated;
+


### PR DESCRIPTION
## Summary
- fetch historical scores from new Supabase `get_historical_scores` RPC function
- animate performance trend chart with Recharts and Framer Motion
- expose SQL function for retrieving history

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689762d6a58483319630d763a9562004