### PR TITLE
feat: improve assessment flow with animated sections

### DIFF
--- a/src/components/EnhancedExport.tsx
+++ b/src/components/EnhancedExport.tsx
@@ -4,13 +4,28 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Download, FileText, Table, Image, Mail } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { DealershipInfo } from '@/types/dealership';
+
+interface Recommendation {
+  priority: string;
+  department: string;
+  title: string;
+  description: string;
+  impact: string;
+  effort: string;
+}
+
+interface Benchmark {
+  metricName: string;
+  averageScore: number;
+}
 
 interface ExportData {
-  dealership: any;
+  dealership: DealershipInfo | null;
   scores: Record<string, number>;
-  answers: Record<string, any>;
-  recommendations: any[];
-  benchmarks?: any[];
+  answers: Record<string, unknown>;
+  recommendations: Recommendation[];
+  benchmarks?: Benchmark[];
 }
 
 interface EnhancedExportProps {
@@ -105,7 +120,7 @@ Report ID: ${Date.now()}
     };
 
     // Convert to CSV format
-    const createCSV = (data: any[]) => {
+    const createCSV = (data: (string | number)[][]) => {
       return data.map(row => row.join(',')).join('\n');
     };
 

--- a/src/components/ExecutiveSummary.tsx
+++ b/src/components/ExecutiveSummary.tsx
@@ -6,7 +6,7 @@ import { TrendingUp, TrendingDown, AlertTriangle, CheckCircle } from "lucide-rea
 interface ExecutiveSummaryProps {
   overallScore: number;
   scores: Record<string, number>;
-  answers: Record<string, any>;
+  answers: Record<string, number>;
   completedAt: string;
 }
 

--- a/src/components/InteractiveRecommendations.tsx
+++ b/src/components/InteractiveRecommendations.tsx
@@ -9,7 +9,7 @@ import { AlertTriangle, CheckCircle, Clock, DollarSign, TrendingUp, BookOpen, Us
 
 interface InteractiveRecommendationsProps {
   scores: Record<string, number>;
-  answers: Record<string, any>;
+  answers: Record<string, number>;
 }
 
 interface Recommendation {

--- a/src/components/KPIInsights.tsx
+++ b/src/components/KPIInsights.tsx
@@ -5,7 +5,7 @@ import { ArrowUp, ArrowDown, DollarSign, TrendingUp, Target } from "lucide-react
 
 interface KPIInsightsProps {
   scores: Record<string, number>;
-  answers: Record<string, any>;
+  answers: Record<string, number>;
 }
 
 interface KPIData {

--- a/src/components/MaturityScoring.tsx
+++ b/src/components/MaturityScoring.tsx
@@ -5,7 +5,7 @@ import { ArrowRight, CheckCircle, Circle, Target, Zap } from "lucide-react";
 
 interface MaturityScoringProps {
   scores: Record<string, number>;
-  answers: Record<string, any>;
+  answers: Record<string, number>;
 }
 
 interface MaturityLevel {

--- a/src/components/assessment/SectionNavigation.tsx
+++ b/src/components/assessment/SectionNavigation.tsx
@@ -11,7 +11,7 @@ interface SectionNavigationProps {
   currentQuestion: number;
   answers: Record<string, number>;
   onNavigate: (sectionIndex: number, questionIndex: number) => void;
-  getSectionIcon: (title: string) => React.ComponentType<any>;
+  getSectionIcon: (title: string) => React.ComponentType<unknown>;
   getSectionColor: (index: number) => string;
 }
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/hooks/useAssessmentData.ts
+++ b/src/hooks/useAssessmentData.ts
@@ -145,7 +145,17 @@ export const useAssessmentData = () => {
 
   // Generate improvement actions
   const generateImprovementActions = useCallback(async (assessmentId: string, scores: Record<string, number>) => {
-    const actions: any[] = [];
+    type DBImprovementAction = {
+      assessment_id: string;
+      department: string;
+      priority: ImprovementAction['priority'];
+      action_title: string;
+      action_description: string;
+      expected_impact: string;
+      estimated_effort: string;
+    };
+
+    const actions: DBImprovementAction[] = [];
     
     // Analyze scores and generate targeted actions
     Object.entries(scores).forEach(([section, score]) => {

--- a/src/pages/Assessment.tsx
+++ b/src/pages/Assessment.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
-import { ChevronLeft, ChevronRight, Car, Wrench, Package, DollarSign, BarChart3, Bot } from "lucide-react";
+import { ChevronLeft, ChevronRight, Car, Wrench, Package, BarChart3, Bot } from "lucide-react";
+import { motion } from "framer-motion";
 import { useToast } from "@/hooks/use-toast";
 import { useNavigate } from "react-router-dom";
 import { QuestionCard } from "@/components/assessment/QuestionCard";
@@ -12,16 +12,14 @@ import { SectionNavigation } from "@/components/assessment/SectionNavigation";
 import { SmartAssistant } from "@/components/SmartAssistant";
 import { questionnaire } from "@/data/questionnaire";
 import { useAssessmentData } from "@/hooks/useAssessmentData";
-import { AssessmentData } from "@/types/dealership";
 
 export default function Assessment() {
   const [currentSection, setCurrentSection] = useState(0);
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const [answers, setAnswers] = useState<Record<string, number>>({});
-  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
-  const [pendingNavigation, setPendingNavigation] = useState<() => void | null>(null);
   const [showAssistant, setShowAssistant] = useState(false);
   const [scores, setScores] = useState<Record<string, number>>({});
+  const questionRefs = useRef<Record<string, HTMLDivElement | null>>({});
   
   const { toast } = useToast();
   const navigate = useNavigate();
@@ -38,43 +36,77 @@ export default function Assessment() {
   const progress = (answeredQuestions / totalQuestions) * 100;
 
   const currentSectionData = sections[currentSection];
-  const currentQuestionData = currentSectionData?.questions[currentQuestion];
 
-  // Calculate real-time scores
-  const calculateScores = useCallback((currentAnswers: Record<string, number>) => {
-    const sectionScores: Record<string, number> = {};
-    
-    sections.forEach((section) => {
-      const sectionAnswers = section.questions
-        .map(q => currentAnswers[q.id])
-        .filter(answer => answer !== undefined);
-      
-      if (sectionAnswers.length > 0) {
-        const average = sectionAnswers.reduce((sum, answer) => sum + answer, 0) / sectionAnswers.length;
-        sectionScores[section.id] = Math.round((average / 5) * 100);
-      }
-    });
-    
-    return sectionScores;
-  }, [sections]);
+  // Calculate weighted scores and overall score using logistic normalization
+  const calculateScores = useCallback(
+    (
+      currentAnswers: Record<string, number>
+    ): { sectionScores: Record<string, number>; overallScore: number } => {
+      const sectionScores: Record<string, number> = {};
+      const sectionWeights: Record<string, number> = {};
+      const sectionCompletion: Record<string, number> = {};
 
-  const handleAnswer = async (questionId: string, value: number) => {
+      sections.forEach((section) => {
+        let weightedTotal = 0;
+        let answeredWeight = 0;
+        let possibleWeight = 0;
+
+        section.questions.forEach((q) => {
+          const weight = q.weight ?? 1;
+          possibleWeight += weight;
+          const answer = currentAnswers[q.id];
+          if (answer !== undefined) {
+            const min = q.scale?.min ?? 1;
+            const max = q.scale?.max ?? 5;
+            const ratio = (answer - min) / (max - min);
+            // Logistic transform emphasises mid-range improvements
+            const logistic = 1 / (1 + Math.exp(-12 * (ratio - 0.5)));
+            const normalized = logistic * 100;
+            weightedTotal += normalized * weight;
+            answeredWeight += weight;
+          }
+        });
+
+        if (answeredWeight > 0) {
+          sectionScores[section.id] = Math.round(weightedTotal / answeredWeight);
+          sectionWeights[section.id] = answeredWeight;
+          sectionCompletion[section.id] = answeredWeight / possibleWeight;
+        }
+      });
+
+      const totalWeight = Object.entries(sectionWeights).reduce(
+        (sum, [id, weight]) => sum + weight * (sectionCompletion[id] || 0),
+        0
+      );
+      const overallScore = totalWeight
+        ? Math.round(
+            Object.entries(sectionScores).reduce(
+              (sum, [id, score]) =>
+                sum + score * sectionWeights[id] * (sectionCompletion[id] || 0),
+              0
+            ) / totalWeight
+          )
+        : 0;
+
+      return { sectionScores, overallScore };
+    },
+    [sections]
+  );
+
+  const handleAnswer = async (questionId: string, value: number, questionIndex: number) => {
     const newAnswers = { ...answers, [questionId]: value };
     setAnswers(newAnswers);
+    setCurrentQuestion(questionIndex);
     
     // Calculate real-time scores
-    const newScores = calculateScores(newAnswers);
-    setScores(newScores);
-    
+    const { sectionScores, overallScore } = calculateScores(newAnswers);
+    setScores(sectionScores);
+
     // Auto-save to local storage
     try {
-      const overallScore = Object.values(newScores).length > 0 
-        ? Math.round(Object.values(newScores).reduce((sum, score) => sum + score, 0) / Object.values(newScores).length)
-        : 0;
-        
       await saveAssessment({
         answers: newAnswers,
-        scores: newScores,
+        scores: sectionScores,
         overallScore,
         status: 'in_progress' as const
       });
@@ -90,48 +122,26 @@ export default function Assessment() {
   };
 
   const navigateToQuestion = (sectionIndex: number, questionIndex: number) => {
-    if (hasUnsavedChanges()) {
-      setPendingNavigation(() => () => {
-        setCurrentSection(sectionIndex);
-        setCurrentQuestion(questionIndex);
-      });
-      setShowConfirmDialog(true);
-    } else {
-      setCurrentSection(sectionIndex);
-      setCurrentQuestion(questionIndex);
-    }
+    setCurrentSection(sectionIndex);
+    setCurrentQuestion(questionIndex);
   };
 
-  const hasUnsavedChanges = () => {
-    if (!currentQuestionData) return false;
-    return !(currentQuestionData.id in answers);
-  };
-
-  const nextQuestion = () => {
-    if (currentQuestion < currentSectionData.questions.length - 1) {
-      setCurrentQuestion(currentQuestion + 1);
-    } else if (currentSection < sections.length - 1) {
+  const nextSection = () => {
+    if (currentSection < sections.length - 1) {
       setCurrentSection(currentSection + 1);
       setCurrentQuestion(0);
     }
   };
 
-  const prevQuestion = () => {
-    if (currentQuestion > 0) {
-      setCurrentQuestion(currentQuestion - 1);
-    } else if (currentSection > 0) {
+  const prevSection = () => {
+    if (currentSection > 0) {
       setCurrentSection(currentSection - 1);
-      setCurrentQuestion(sections[currentSection - 1].questions.length - 1);
+      setCurrentQuestion(0);
     }
   };
 
-  const canGoNext = () => {
-    return currentSection < sections.length - 1 || currentQuestion < currentSectionData.questions.length - 1;
-  };
-
-  const canGoPrev = () => {
-    return currentSection > 0 || currentQuestion > 0;
-  };
+  const canGoNextSection = () => currentSection < sections.length - 1;
+  const canGoPrevSection = () => currentSection > 0;
 
   const getSectionIcon = (sectionTitle: string) => {
     if (sectionTitle.includes("New Vehicle")) return Car;
@@ -146,7 +156,7 @@ export default function Assessment() {
     return colors[index % colors.length];
   };
 
-  // Load existing assessment data on mount (only once)
+  // Load existing assessment data on mount
   useEffect(() => {
     const loadExistingData = async () => {
       try {
@@ -155,9 +165,9 @@ export default function Assessment() {
         console.error('Failed to load assessment:', error);
       }
     };
-    
+
     loadExistingData();
-  }, []); // Remove dependencies to prevent infinite loop
+  }, [loadAssessment]);
 
   // Sync with loaded assessment data
   useEffect(() => {
@@ -167,12 +177,16 @@ export default function Assessment() {
     }
   }, [assessment]);
 
+  useEffect(() => {
+    const question = sections[currentSection]?.questions[currentQuestion];
+    if (question) {
+      questionRefs.current[question.id]?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [currentSection, currentQuestion, sections]);
+
   const handleFinishAssessment = async () => {
     try {
-      const finalScores = calculateScores(answers);
-      const overallScore = Object.values(finalScores).length > 0 
-        ? Math.round(Object.values(finalScores).reduce((sum, score) => sum + score, 0) / Object.values(finalScores).length)
-        : 0;
+      const { sectionScores: finalScores, overallScore } = calculateScores(answers);
         
       // Check if all questions are answered
       const totalQuestions = sections.reduce((total, section) => total + section.questions.length, 0);
@@ -273,53 +287,56 @@ export default function Assessment() {
                   <div>
                     <CardTitle className="text-xl">{currentSectionData.title}</CardTitle>
                     <p className="text-blue-100 text-sm">
-                      Question {currentQuestion + 1} of {currentSectionData.questions.length}
+                      {currentSectionData.questions.length} questions in this section
                     </p>
                   </div>
                 </div>
               </CardHeader>
-              
-              <CardContent className="p-6">
-                {currentQuestionData && (
-                  <QuestionCard
-                    question={currentQuestionData}
-                    value={answers[currentQuestionData.id]}
-                    onChange={(value) => handleAnswer(currentQuestionData.id, value)}
-                  />
-                )}
 
-                {/* Navigation Buttons */}
-                <div className="flex justify-between mt-8">
+              <CardContent className="p-6 space-y-10">
+                {currentSectionData.questions.map((question, index) => (
+                  <motion.div
+                    key={question.id}
+                    ref={(el) => (questionRefs.current[question.id] = el)}
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.05 }}
+                  >
+                    <QuestionCard
+                      question={question}
+                      value={answers[question.id]}
+                      onChange={(value) => handleAnswer(question.id, value, index)}
+                    />
+                  </motion.div>
+                ))}
+
+                {/* Section Navigation Buttons */}
+                <div className="flex justify-between pt-4">
                   <Button
                     variant="outline"
-                    onClick={prevQuestion}
-                    disabled={!canGoPrev()}
+                    onClick={prevSection}
+                    disabled={!canGoPrevSection()}
                     className="flex items-center gap-2"
                   >
                     <ChevronLeft className="h-4 w-4" />
-                    Previous
+                    Previous Section
                   </Button>
 
-                  <div className="flex gap-2">
-                    {canGoNext() ? (
-                      <Button
-                        onClick={nextQuestion}
-                        className="flex items-center gap-2"
-                      >
-                        Next
-                        <ChevronRight className="h-4 w-4" />
-                      </Button>
-                    ) : (
-                      <Button
-                        onClick={handleFinishAssessment}
-                        className="flex items-center gap-2 bg-green-600 hover:bg-green-700"
-                        disabled={isLoading}
-                      >
-                        {isLoading ? 'Saving...' : 'View Results'}
-                        <BarChart3 className="h-4 w-4" />
-                      </Button>
-                    )}
-                  </div>
+                  {canGoNextSection() ? (
+                    <Button onClick={nextSection} className="flex items-center gap-2">
+                      Next Section
+                      <ChevronRight className="h-4 w-4" />
+                    </Button>
+                  ) : (
+                    <Button
+                      onClick={handleFinishAssessment}
+                      className="flex items-center gap-2 bg-green-600 hover:bg-green-700"
+                      disabled={isLoading}
+                    >
+                      {isLoading ? 'Saving...' : 'Finish Assessment'}
+                      <BarChart3 className="h-4 w-4" />
+                    </Button>
+                  )}
                 </div>
               </CardContent>
             </Card>
@@ -340,38 +357,11 @@ export default function Assessment() {
         <SmartAssistant
           open={showAssistant}
           onOpenChange={setShowAssistant}
-          currentQuestion={currentQuestionData}
+          currentQuestion={sections[currentSection].questions[currentQuestion]}
           currentSection={currentSectionData}
           answers={answers}
           scores={scores}
         />
-
-
-        {/* Confirmation Dialog */}
-        <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Unsaved Changes</AlertDialogTitle>
-              <AlertDialogDescription>
-                You have unsaved changes on this question. Are you sure you want to navigate away?
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={() => {
-                  if (pendingNavigation) {
-                    pendingNavigation();
-                    setPendingNavigation(null);
-                  }
-                  setShowConfirmDialog(false);
-                }}
-              >
-                Continue
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
       </div>
     </div>
   );

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -17,10 +17,29 @@ import { KPIInsights } from "@/components/KPIInsights";
 import { MaturityScoring } from "@/components/MaturityScoring";
 import { InteractiveRecommendations } from "@/components/InteractiveRecommendations";
 
+interface CompletedAssessmentResults {
+  answers: Record<string, number>;
+  scores: Record<string, number>;
+  overallScore: number;
+  completedAt: string;
+}
+
+interface RecommendationAction {
+  id: number;
+  department: string;
+  priority: 'critical' | 'high' | 'medium';
+  emoji: string;
+  title: string;
+  description: string;
+  impact: string;
+  effort: string;
+  score: number;
+}
+
 export default function Results() {
   const [activeTab, setActiveTab] = useState("executive");
-  const [improvementActions, setImprovementActions] = useState<any[]>([]);
-  const [resultsData, setResultsData] = useState<any>(null);
+  const [improvementActions, setImprovementActions] = useState<RecommendationAction[]>([]);
+  const [resultsData, setResultsData] = useState<CompletedAssessmentResults | null>(null);
   const [isExporting, setIsExporting] = useState(false);
   
   const { toast } = useToast();
@@ -45,7 +64,7 @@ export default function Results() {
   }, [navigate, toast]);
 
   const generateImprovementActions = (scores: Record<string, number>) => {
-    const actions: any[] = [];
+    const actions: RecommendationAction[] = [];
     
     Object.entries(scores).forEach(([section, score]) => {
       if (score < 75) {

--- a/src/types/dealership.ts
+++ b/src/types/dealership.ts
@@ -12,7 +12,7 @@ export interface AssessmentData {
   id?: string;
   dealershipId?: string;
   sessionId: string;
-  answers: Record<string, any>;
+  answers: Record<string, number>;
   scores: Record<string, number>;
   overallScore?: number;
   status: 'in_progress' | 'completed' | 'archived';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- render all questions in each assessment section at once and animate them with framer-motion
- add section-level navigation controls to move between sections or finish the assessment
- enhance scoring engine with logistic normalization and completion-weighted section scores for more nuanced results

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897b0fccb408331a2fdd28cc61e39f9