### PR TITLE
feat: add module filter to historical scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 ## Notes
 - Supabase URL and anon key are now loaded from environment variables.
 - Template identifiers have been removed.
+- `get_historical_scores` RPC accepts an optional `module_slug` argument to fetch module-specific trends; omit or set to `null` to include all modules.

--- a/src/components/EnhancedCharts.tsx
+++ b/src/components/EnhancedCharts.tsx
@@ -13,6 +13,8 @@ interface EnhancedChartsProps {
   benchmarks?: Record<string, number>;
   trends?: Record<string, number>;
   dealershipId?: string;
+  /** Optional module identifier to scope historical trends */
+  moduleSlug?: string;
 }
 
 const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4'];
@@ -20,7 +22,9 @@ const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4'
 export const EnhancedCharts: React.FC<EnhancedChartsProps> = ({
   scores,
   benchmarks = {},
-  trends = {}
+  trends = {},
+  dealershipId,
+  moduleSlug,
 }) => {
   // Prepare data for charts
   const radarData = Object.entries(scores).map(([key, value]) => ({
@@ -65,9 +69,14 @@ export const EnhancedCharts: React.FC<EnhancedChartsProps> = ({
     if (!dealershipId) return;
 
     const fetchData = async () => {
-      const { data, error } = await supabase.rpc('get_historical_scores', {
+      const params: { dealership_id: string; module_slug?: string } = {
         dealership_id: dealershipId,
-      });
+      };
+      if (moduleSlug) {
+        params.module_slug = moduleSlug;
+      }
+
+      const { data, error } = await supabase.rpc('get_historical_scores', params);
       if (!error && data) {
         const mapped = data.map((row: { created_at: string; overall_score: number }) => ({
           month: new Date(row.created_at).toLocaleDateString('en', { month: 'short' }),
@@ -104,7 +113,7 @@ export const EnhancedCharts: React.FC<EnhancedChartsProps> = ({
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [dealershipId]);
+  }, [dealershipId, moduleSlug]);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/supabase/migrations/20250803050000_get_historical_scores.sql
+++ b/supabase/migrations/20250803050000_get_historical_scores.sql
@@ -1,15 +1,24 @@
 -- create function to fetch historical scores for a dealership
-create or replace function public.get_historical_scores(dealership_id uuid)
+-- optional module filtering allows querying trends for a specific module
+create or replace function public.get_historical_scores(
+  dealership_id uuid,
+  module_slug text default null
+)
 returns table(
   created_at timestamptz,
   overall_score double precision
 ) as $$
-  select created_at, overall_score
-  from assessments
-  where assessments.dealership_id = get_historical_scores.dealership_id
-  order by created_at;
+  select a.created_at, a.overall_score
+  from assessments a
+  left join modules m on a.module_id = m.id
+  where a.dealership_id = get_historical_scores.dealership_id
+    and (
+      get_historical_scores.module_slug is null
+      or m.slug = get_historical_scores.module_slug
+    )
+  order by a.created_at;
 $$ language sql stable;
 
 -- allow anon and authenticated users to execute
-grant execute on function public.get_historical_scores(uuid) to anon, authenticated;
+grant execute on function public.get_historical_scores(uuid, text) to anon, authenticated;
 


### PR DESCRIPTION
## Summary
- allow `get_historical_scores` to filter by module
- wire `moduleSlug` through `EnhancedCharts` to scope historical trends
- document optional `module_slug` RPC argument

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any / other existing lint errors)*
- `npx eslint src/components/EnhancedCharts.tsx && echo "Lint passed"`


------
https://chatgpt.com/codex/tasks/task_e_689a49ba9de483318b7a5556c00021e4