### PR TITLE
chore: relax ESLint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,9 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
       "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-empty-object-type": "off",
+      "@typescript-eslint/no-require-imports": "off",
     },
   }
 );


### PR DESCRIPTION
## Summary
- disable strict TypeScript rules that caused lint errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a49ba9de483318b7a5556c00021e4