### PR TITLE
feat: add overall assessment scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 ## Notes
 - Supabase URL and anon key are now loaded from environment variables.
 - Template identifiers have been removed.
+
+## Multi-Module Assessments
+
+Early support for running assessments across multiple modules is under development.  
+Scoring rules include an `overall` rollup for aggregating module results.

--- a/docs/multi-module-assessments.md
+++ b/docs/multi-module-assessments.md
@@ -1,0 +1,7 @@
+# Multi-Module Assessments
+
+This project is evolving toward supporting assessments that span one or more modules.  
+The data model introduces a parent **assessment run** containing one or more module sessions.  
+Rules allow computing an overall weighted score across modules.
+
+This document captures the early design for multi-module flows and scoring.

--- a/src/lib/rules/overall.ts
+++ b/src/lib/rules/overall.ts
@@ -1,0 +1,28 @@
+import { ModuleScore, Maturity } from '@/types/assessment';
+
+/**
+ * Compute a weighted average score across modules and derive overall maturity.
+ * Weights default to 100 when not provided or invalid.
+ */
+export function computeOverallScore(
+  modules: ModuleScore[],
+  weights: Record<string, number> = {}
+): { overall_score: number; overall_maturity: Maturity } {
+  let numerator = 0;
+  let denominator = 0;
+  for (const mod of modules) {
+    const w = Math.max(1, weights[mod.module_id] ?? 100);
+    numerator += mod.score * w;
+    denominator += w;
+  }
+  const overall_score = denominator ? Math.round((numerator / denominator) * 10) / 10 : 0;
+  const overall_maturity: Maturity =
+    overall_score >= 85
+      ? 'Advanced'
+      : overall_score >= 70
+        ? 'Proficient'
+        : overall_score >= 55
+          ? 'Emerging'
+          : 'Basic';
+  return { overall_score, overall_maturity };
+}

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -1,0 +1,26 @@
+export type RunMode = 'single' | 'multi' | 'all';
+
+export interface AssessmentRun {
+  id: string;
+  dealer_id: string;
+  mode: RunMode;
+  selected_module_ids: string[];
+  status: 'in_progress' | 'completed';
+  started_at: string;
+  completed_at?: string;
+  meta?: Record<string, unknown>;
+}
+
+export type Maturity = 'Basic' | 'Emerging' | 'Proficient' | 'Advanced';
+
+export interface ModuleScore {
+  module_id: string;
+  score: number; // 0-100
+  maturity: Maturity;
+}
+
+export interface OverallScore {
+  overall_score: number;
+  overall_maturity: Maturity;
+  module_breakdown: ModuleScore[];
+}


### PR DESCRIPTION
## Summary
- add assessment and scoring types
- introduce weighted overall scoring rule
- document early multi-module assessment design

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689a52ebe0a88331a228fdbad2dbdfca